### PR TITLE
Add better management of SIGTERM for the elasticsearch child process of run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ ENV DISCOVERY_SERVICE elasticsearch-discovery
 # Volume for Elasticsearch data
 VOLUME ["/data"]
 
+# Run elasticsearch as unprivileged
 RUN chown elasticsearch:elasticsearch -R /usr/share/elasticsearch /data && \
     chown elasticsearch:elasticsearch -R /opt/jdk-10.0.2/conf
 USER elasticsearch

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,15 @@ ENV SHARD_ALLOCATION_AWARENESS_ATTR ""
 ENV MEMORY_LOCK false
 ENV REPO_LOCATIONS ""
 ENV DISCOVERY_SERVICE elasticsearch-discovery
+ENV NETWORK_ADDRESS_CACHE_TTL 3
+ENV NETWORK_ADDRESS_CACHE_NEGATIVE_TTL 10
+ENV DISCOVERY_SERVICE elasticsearch-discovery
 
 # Volume for Elasticsearch data
 VOLUME ["/data"]
 
-RUN chown elasticsearch:elasticsearch -R /usr/share/elasticsearch /data
+RUN chown elasticsearch:elasticsearch -R /usr/share/elasticsearch /data && \
+    chown elasticsearch:elasticsearch -R /opt/jdk-10.0.2/conf
 USER elasticsearch
 
 CMD ["/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -89,5 +89,6 @@ fi
 
 PID="$!"
 
-echo "Setting ES pid to $PID"
-
+while true ; do
+   tail -f /dev/null & wait ${!}
+done

--- a/run.sh
+++ b/run.sh
@@ -55,11 +55,11 @@ if [[ $(whoami) == "root" ]]; then
     chown -R elasticsearch:elasticsearch /data
     exec su-exec elasticsearch $BASE/bin/elasticsearch $ES_EXTRA_ARGS
 else
-    # the container's first process is not running as 'root', 
+    # the container's first process is not running as 'root',
     # it does not have the rights to chown. however, we may
     # assume that it is being ran as 'elasticsearch', and that
     # the volumes already have the right permissions. this is
     # the case for kubernetes for example, when 'runAsUser: 1000'
     # and 'fsGroup:1000' are defined in the pod's security context.
-    $BASE/bin/elasticsearch $ES_EXTRA_ARGS
+    exec $BASE/bin/elasticsearch $ES_EXTRA_ARGS
 fi

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ set -ex
 # SIGTERM-handler
 term_handler() {
   if [ $PID -ne 0 ]; then
-    kill -SIGTERM "$PID"
+    pkill -SIGTERM "$PID"
     wait "$PID"
     sleep 10
   fi

--- a/scripts/pre-stop-master.sh
+++ b/scripts/pre-stop-master.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-pkill -SIGTERM java
+# Disable since now the run.sh entrypoint will deal with SIGTERMing java
+#pkill -SIGTERM java
+exit 0

--- a/scripts/stop-local-routing.sh
+++ b/scripts/stop-local-routing.sh
@@ -17,9 +17,10 @@ while true ; do
   echo -e "Wait for node ${NODE_NAME} to become empty"
   SHARDS_ALLOCATION=$(curl --retry 3 -s -XGET 'http://localhost:9200/_cat/shards')
   if ! echo "${SHARDS_ALLOCATION}" | grep -E "${NODE_NAME}"; then
-    # Send Sigterm to elasticsearch once the relocation is finished
-    sleep 2
-    pkill -SIGTERM -P 1
+    # Send Sigterm to elasticsearch once the relocation is finished 
+    # Disabled since now the run.sh entrypoint will deal with sigterming the right process
+    # sleep 2
+    # pkill -SIGTERM -P 1
     break
   fi
   sleep 2


### PR DESCRIPTION
Use example from https://github.com/pires/kubernetes-elasticsearch-cluster/issues/146#issuecomment-340601102 to better manage the SIGTERM of the elasticsearch process when the container is TERMed

* trap SIGTERM And term the java process pid
* SLEEP for 15 seconds ( Configurable ) after waiting for PID to terminate to try address issues:
  * https://github.com/pires/kubernetes-elasticsearch-cluster/issues/231
  * https://gitlab.com/mintel/satoshi/infrastructure/terragrunt-satoshi-cluster-infrastructure/issues/90
* remove pkilling from "stop" scripts
* remove ability to run process as root , this container is only for running as unprivileged user 