### PR TITLE
Kubernetes Nodes-Label based shard allocation awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ push persistent settings to the cluster
 * [ES_PLUGINS_INSTALL](https://www.elastic.co/guide/en/elasticsearch/plugins/current/installation.html) - comma separated list of Elasticsearch plugins to be installed. Example: `ES_PLUGINS_INSTALL="repository-gcs,x-pack"`
 * [SHARD_ALLOCATION_AWARENESS](https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html#CO287-1)
 * [SHARD_ALLOCATION_AWARENESS_ATTR](https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html#CO287-1)
+* KUBERNETES_SHARD_ALLOCATION_AWARENESS - Enable SHARD Allocation awareness for a Kubernetes Cluster using labels
+  * server = WORKER NODE NAME
+	* zone = Kubernetes failure domain zone ( Only for cloud )
 * [MEMORY_LOCK](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#bootstrap.memory_lock) - memory locking control - enable to prevent swap (default = `true`) .
 * [REPO_LOCATIONS](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_shared_file_system_repository) - list of registered repository locations. For example `"/backup"` (default = `[]`). The value of REPO_LOCATIONS is automatically wrapped within an `[]` and therefore should not be included in the variable declaration. To specify multiple repository locations simply specify a comma separated string for example `"/backup", "/backup2"`.
 * [PROCESSORS](https://github.com/elastic/elasticsearch-definitive-guide/pull/679/files) - allow elasticsearch to optimize for the actual number of available cpus (must be an integer - default = 1)

--- a/examples/minikube/3-master-statefulset.yml
+++ b/examples/minikube/3-master-statefulset.yml
@@ -57,6 +57,7 @@ spec:
       securityContext:
         runAsUser: 1000
         fsGroup: 1000
+      serviceAccountName: elasticsearch
       terminationGracePeriodSeconds: 180
       containers:
         - name: elasticsearch
@@ -76,6 +77,8 @@ spec:
                   fieldPath: metadata.name
             - name: CLUSTER_NAME
               value: logs
+            - name: KUBERNETES_SHARD_ALLOCATION_AWARENESS
+              value: "True"
             - name: DISCOVERY_SERVICE
               value: "elasticsearch-discovery.monitoring.svc.cluster.local"
             - name: MINIMUM_NUMBER_OF_MASTERS

--- a/examples/minikube/3-node-statefulset.yml
+++ b/examples/minikube/3-node-statefulset.yml
@@ -55,6 +55,7 @@ spec:
       securityContext:
         runAsUser: 1000
         fsGroup: 1000
+      serviceAccountName: elasticsearch
       terminationGracePeriodSeconds: 180
       containers:
         - name: elasticsearch
@@ -75,6 +76,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: KUBERNETES_SHARD_ALLOCATION_AWARENESS
+              value: "True"
             - name: RECOVERY_MAX_BYTES
               value: 20mb
             - name: CLUSTER_NAME

--- a/examples/minikube/rbac.yml
+++ b/examples/minikube/rbac.yml
@@ -1,0 +1,40 @@
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app: elasticsearch
+  name: elasticsearch
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app: elasticsearch
+  name: elasticsearch
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app: elasticsearch
+  name: elasticsearch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: elasticsearch
+subjects:
+- kind: ServiceAccount
+  name: elasticsearch
+  namespace: monitoring
+


### PR DESCRIPTION
Add support for pulling shard allocation attributes from Kubernetes nodes labels.

 - failure-domain.beta.kubernetes.io/zone -> zone
 - kubernetes.io/hostname -> server

