### PR TITLE
Add gcs credentials to keystore if provided

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -130,6 +130,13 @@ trap 'kill ${!}; term_handler' SIGTERM
 $BASE/bin/elasticsearch $ES_EXTRA_ARGS &
 PID="$!"
 
+if [ ! -z "${ES_GCS_CREDENTIALS_FILE}" ]; then
+  until $BASE/bin/elasticsearch-keystore add-file gcs.client.default.credentials_file ${ES_GCS_CREDENTIALS_FILE}; do
+    echo "failed to add keystore file ${file}, retrying in 3s"
+    sleep 3
+  done
+fi
+
 while true ; do
    tail -f /dev/null & wait ${!}
 done


### PR DESCRIPTION
The keystore addition must be run on every node in the cluster after ElasticSearch is running.

We'll be using these credentials to allow the GCS snapshot repository plugin to authenticate.

Case reference mintel/satoshi/planning#138